### PR TITLE
fix read off end of src in houdini_unescape_html

### DIFF
--- a/src/houdini.c
+++ b/src/houdini.c
@@ -63,7 +63,7 @@ houdini_unescape_html(struct buf *ob, const char *src, size_t size)
 			break;
 
 		#define REPLACE(pat,rep)\
-			if (i + sizeof(pat) <= size && !memcmp(src + i + 1, pat, sizeof(pat) - 1)) { bufputc(ob, rep); i += sizeof(pat) - 1; }
+			if (i + sizeof(pat) <= size && !memcmp(src + i + 1, pat, sizeof(pat) - 1)) { bufputc(ob, rep); i += sizeof(pat); }
 
 		REPLACE("lt;", '<')
 		else REPLACE("gt;", '>')


### PR DESCRIPTION
houdini_unescape_html reads off the end of the src buffer if the buffer ends with some prefix of a valid escape sequence.
